### PR TITLE
fix: refactor v3 worldometer apis

### DIFF
--- a/public/api_data.js
+++ b/public/api_data.js
@@ -1,30 +1,6 @@
 define({ "api": [
   {
     "type": "get",
-    "url": "/v3/analytics/country",
-    "title": "By country",
-    "name": "FetchAffectedCountries",
-    "group": "Analytics",
-    "version": "3.0.0",
-    "parameter": {
-      "fields": {
-        "Parameter": [
-          {
-            "group": "Parameter",
-            "type": "Number",
-            "optional": true,
-            "field": "limit",
-            "defaultValue": "200",
-            "description": "<p>limit the number of results</p>"
-          }
-        ]
-      }
-    },
-    "filename": "routes/v3/analytics.js",
-    "groupTitle": "Analytics"
-  },
-  {
-    "type": "get",
     "url": "/v2/analytics/country",
     "title": "By country",
     "name": "FetchAffectedCountries",
@@ -223,9 +199,9 @@ define({ "api": [
   },
   {
     "type": "get",
-    "url": "/v3/analytics/daily",
+    "url": "/v3/analytics/dailyNewStats",
     "title": "By new daily cases and deaths",
-    "name": "fetchTopCountryWithDailyNewCases",
+    "name": "fetchTopCountryWithDailyNewStatsSortByNewCases",
     "group": "Analytics",
     "version": "3.0.0",
     "parameter": {
@@ -242,6 +218,43 @@ define({ "api": [
         ]
       }
     },
+    "filename": "routes/v3/analytics.js",
+    "groupTitle": "Analytics"
+  },
+  {
+    "type": "get",
+    "url": "/v3/analytics/trend/country",
+    "title": "get data of a country between start and end dates",
+    "name": "getTrendByCountry",
+    "group": "Analytics",
+    "parameter": {
+      "fields": {
+        "Parameter": [
+          {
+            "group": "Parameter",
+            "type": "String",
+            "optional": true,
+            "field": "countryCode",
+            "description": "<p>Required Country code(s)</p>"
+          },
+          {
+            "group": "Parameter",
+            "type": "Date",
+            "optional": true,
+            "field": "startDate",
+            "description": "<p>Required Start date</p>"
+          },
+          {
+            "group": "Parameter",
+            "type": "Date",
+            "optional": true,
+            "field": "endDate",
+            "description": "<p>Required end date</p>"
+          }
+        ]
+      }
+    },
+    "version": "0.0.0",
     "filename": "routes/v3/analytics.js",
     "groupTitle": "Analytics"
   },
@@ -820,7 +833,7 @@ define({ "api": [
   },
   {
     "type": "get",
-    "url": "/v3/stats/total_trending_cases",
+    "url": "/v3/stats/worldometer/totalTrendingCases",
     "title": "",
     "name": "GetTotalTrendingCases",
     "group": "Stats",
@@ -835,7 +848,7 @@ define({ "api": [
         }
       ]
     },
-    "filename": "routes/v3/stats.js",
+    "filename": "routes/v3/stats/worldometer.js",
     "groupTitle": "Stats"
   },
   {
@@ -947,8 +960,8 @@ define({ "api": [
   {
     "type": "get",
     "url": "/v3/stats/worldometer/global",
-    "title": "Global stats",
-    "name": "stats_overview",
+    "title": "Global Stats Overview",
+    "name": "globalStatsOverview",
     "group": "Stats_-_Worldometer",
     "version": "3.0.0",
     "description": "<p>Returns global stats based on worldometer data, used in home and analytics page</p>",
@@ -999,7 +1012,7 @@ define({ "api": [
   },
   {
     "type": "get",
-    "url": "/v3/stats/worldometer/top",
+    "url": "/v3/stats/worldometer/topCountry",
     "title": "Top N countries",
     "name": "worldometer",
     "group": "Stats_-_Worldometer",

--- a/public/api_data.json
+++ b/public/api_data.json
@@ -1,30 +1,6 @@
 [
   {
     "type": "get",
-    "url": "/v3/analytics/country",
-    "title": "By country",
-    "name": "FetchAffectedCountries",
-    "group": "Analytics",
-    "version": "3.0.0",
-    "parameter": {
-      "fields": {
-        "Parameter": [
-          {
-            "group": "Parameter",
-            "type": "Number",
-            "optional": true,
-            "field": "limit",
-            "defaultValue": "200",
-            "description": "<p>limit the number of results</p>"
-          }
-        ]
-      }
-    },
-    "filename": "routes/v3/analytics.js",
-    "groupTitle": "Analytics"
-  },
-  {
-    "type": "get",
     "url": "/v2/analytics/country",
     "title": "By country",
     "name": "FetchAffectedCountries",
@@ -223,9 +199,9 @@
   },
   {
     "type": "get",
-    "url": "/v3/analytics/daily",
+    "url": "/v3/analytics/dailyNewStats",
     "title": "By new daily cases and deaths",
-    "name": "fetchTopCountryWithDailyNewCases",
+    "name": "fetchTopCountryWithDailyNewStatsSortByNewCases",
     "group": "Analytics",
     "version": "3.0.0",
     "parameter": {
@@ -242,6 +218,43 @@
         ]
       }
     },
+    "filename": "routes/v3/analytics.js",
+    "groupTitle": "Analytics"
+  },
+  {
+    "type": "get",
+    "url": "/v3/analytics/trend/country",
+    "title": "get data of a country between start and end dates",
+    "name": "getTrendByCountry",
+    "group": "Analytics",
+    "parameter": {
+      "fields": {
+        "Parameter": [
+          {
+            "group": "Parameter",
+            "type": "String",
+            "optional": true,
+            "field": "countryCode",
+            "description": "<p>Required Country code(s)</p>"
+          },
+          {
+            "group": "Parameter",
+            "type": "Date",
+            "optional": true,
+            "field": "startDate",
+            "description": "<p>Required Start date</p>"
+          },
+          {
+            "group": "Parameter",
+            "type": "Date",
+            "optional": true,
+            "field": "endDate",
+            "description": "<p>Required end date</p>"
+          }
+        ]
+      }
+    },
+    "version": "0.0.0",
     "filename": "routes/v3/analytics.js",
     "groupTitle": "Analytics"
   },
@@ -820,7 +833,7 @@
   },
   {
     "type": "get",
-    "url": "/v3/stats/total_trending_cases",
+    "url": "/v3/stats/worldometer/totalTrendingCases",
     "title": "",
     "name": "GetTotalTrendingCases",
     "group": "Stats",
@@ -835,7 +848,7 @@
         }
       ]
     },
-    "filename": "routes/v3/stats.js",
+    "filename": "routes/v3/stats/worldometer.js",
     "groupTitle": "Stats"
   },
   {
@@ -947,8 +960,8 @@
   {
     "type": "get",
     "url": "/v3/stats/worldometer/global",
-    "title": "Global stats",
-    "name": "stats_overview",
+    "title": "Global Stats Overview",
+    "name": "globalStatsOverview",
     "group": "Stats_-_Worldometer",
     "version": "3.0.0",
     "description": "<p>Returns global stats based on worldometer data, used in home and analytics page</p>",
@@ -999,7 +1012,7 @@
   },
   {
     "type": "get",
-    "url": "/v3/stats/worldometer/top",
+    "url": "/v3/stats/worldometer/topCountry",
     "title": "Top N countries",
     "name": "worldometer",
     "group": "Stats_-_Worldometer",

--- a/public/api_project.js
+++ b/public/api_project.js
@@ -21,7 +21,7 @@ define({
   "apidoc": "0.3.0",
   "generator": {
     "name": "apidoc",
-    "time": "2020-03-24T14:29:43.330Z",
+    "time": "2020-03-25T05:11:29.519Z",
     "url": "http://apidocjs.com",
     "version": "0.20.0"
   }

--- a/public/api_project.json
+++ b/public/api_project.json
@@ -21,7 +21,7 @@
   "apidoc": "0.3.0",
   "generator": {
     "name": "apidoc",
-    "time": "2020-03-24T14:29:43.330Z",
+    "time": "2020-03-25T05:11:29.519Z",
     "url": "http://apidocjs.com",
     "version": "0.20.0"
   }

--- a/routes/v3/stats.js
+++ b/routes/v3/stats.js
@@ -140,27 +140,7 @@ router.get('/custom-debug', cacheCheck, cache.route(), asyncHandler(async functi
   return res.json(result);
 }));
 
-/**
- * @api {get} /v3/stats/total_trending_cases
- * @apiName GetTotalTrendingCases
- * @apiGroup Stats
- * @apiVersion 3.0.0
- * @apiDescription Returns total trending cases
- * @apiSuccessExample Response (example):
- * HTTP/1.1 200 Success
-[
-  {
-    "totalConfirmed": 378560,
-    "totalDeaths": 16495,
-    "totalRecovered": 101608,
-    "lastUpdated": "2020-03-24T00:10:06.000Z"
-  },
-]
- */
-router.get('/total_trending_cases', cacheCheck, cache.route(), asyncHandler(async function(req, res, next) {
-  const result = await getTotalTrendingCases();
-  return res.json(result);
-}));
+
 
 /**
  * @api {get} /v3/stats/diff/global Diff global stats
@@ -314,20 +294,6 @@ ORDER BY b.cases DESC;`;
     recovered: Math.max(data.recovered, customCountryStat.recovered),
     created: data.created > customCountryStat.created ? data.created : customCountryStat.created,
   }
-}
-
-async function getTotalTrendingCases() {
-  const conn = db.conn.promise();
-  let query = `
-  SELECT total_cases AS totalConfirmed, total_deaths as totalDeaths, total_recovered as totalRecovered, last_updated as lastUpdated
-  FROM worldometers_total_sum_temp
-  GROUP BY date(last_updated)
-  ORDER BY last_updated DESC;
-`;
-
-  let result = await conn.query(query);
-
-  return result[0];
 }
 
 async function getLatestArcgisStats() {

--- a/routes/v3/stats/worldometer.js
+++ b/routes/v3/stats/worldometer.js
@@ -3,7 +3,8 @@ const router = express.Router();
 const asyncHandler = require("express-async-handler");
 const db = require('../../../system/database');
 const cache = require('../../../system/redis-cache');
-const { getCustomStats, fetchDataFromGoogleSheet } = require('../../../services/customStats');
+const { getCountryStats } = require('../../../services/statsService');
+const { fetchDataFromGoogleSheet } = require('../../../services/customStats');
 const { cacheCheck } = require('../../../services/cacheMiddleware');
 
  /**
@@ -51,8 +52,8 @@ router.get('/country', cacheCheck, cache.route(), asyncHandler(async function(re
 }));
 
 /**
- * @api {get} /v3/stats/worldometer/global Global stats
- * @apiName stats_overview
+ * @api {get} /v3/stats/worldometer/global Global Stats Overview
+ * @apiName globalStatsOverview
  * @apiGroup Stats - Worldometer
  * @apiVersion 3.0.0
  * @apiDescription Returns global stats based on worldometer data, used in home and analytics page
@@ -82,7 +83,7 @@ router.get('/global', cacheCheck, cache.route(), asyncHandler(async function (re
 }));
 
 /**
- * @api {get} /v3/stats/worldometer/top Top N countries
+ * @api {get} /v3/stats/worldometer/topCountry Top N countries
  * @apiName worldometer
  * @apiGroup Stats - Worldometer
  * @apiVersion 3.0.0
@@ -110,8 +111,8 @@ router.get('/global', cacheCheck, cache.route(), asyncHandler(async function (re
   }
 ]
  */
-router.get('/top', cacheCheck, cache.route(), asyncHandler(async function(req, res, next) {
-  // console.log('calling /v3/stats/worldometer/top');
+router.get('/topCountry', cacheCheck, cache.route(), asyncHandler(async function(req, res, next) {
+  // console.log('calling /v3/stats/worldometer/topCountry');
   let limit = 999
 
   if (req.query.hasOwnProperty('limit')) {
@@ -123,7 +124,35 @@ router.get('/top', cacheCheck, cache.route(), asyncHandler(async function(req, r
     return res.json(result);
   }
   catch (error) {
-    console.log('[/v3/stats/worldometer/top] error', error);
+    console.log('[/v3/stats/worldometer/topCountry] error', error);
+    return res.json(error);
+  }
+}));
+
+/**
+ * @api {get} /v3/stats/worldometer/totalTrendingCases
+ * @apiName GetTotalTrendingCases
+ * @apiGroup Stats
+ * @apiVersion 3.0.0
+ * @apiDescription Returns total trending cases
+ * @apiSuccessExample Response (example):
+ * HTTP/1.1 200 Success
+[
+  {
+    "totalConfirmed": 378560,
+    "totalDeaths": 16495,
+    "totalRecovered": 101608,
+    "lastUpdated": "2020-03-24T00:10:06.000Z"
+  },
+]
+ */
+router.get('/totalTrendingCases', cacheCheck, cache.route(), asyncHandler(async function(req, res, next) {
+  try {
+  const result = await getTotalTrendingCases();
+    return res.json(result);
+  }
+  catch (error) {
+    console.log('[/v3/stats/worldometer/totalTrendingCases] error', error);
     return res.json(error);
   }
 }));
@@ -176,143 +205,17 @@ async function getGlobalStats() {
   return result[0][0];
 }
 
-async function getCountryStats(countryCode=null, limit=999) {
-
+async function getTotalTrendingCases() {
   const conn = db.conn.promise();
-  let countryCodeQuery = ''
-  let args = []
-  let getAllFlag = true
-
-  const blacklistCountryQuery = `where country not in ("Sint Maarten","Congo", "South Korea", "Czechia Republic", "Czech Republic", "Others")`
-
-  if (countryCode) {
-    countryCodeQuery = 'WHERE ac.country_code=?'
-    args.push(countryCode)
-    getAllFlag = false
-  }
-  args.push(parseInt(limit))
-
   let query = `
-  SELECT ac.country_code AS countryCode, tt.country, ac.latitude + 0.0 AS lat, ac.longitude + 0.0 AS lng, tt.total_cases AS totalConfirmed, tt.total_deaths AS totalDeaths, tt.total_recovered AS totalRecovered, tt.new_cases AS dailyConfirmed, tt.new_deaths AS dailyDeaths, tt.active_cases AS activeCases, tt.serious_critical_cases AS totalCritical, CAST(tt.total_cases_per_million_pop AS UNSIGNED) AS totalConfirmedPerMillionPopulation, (tt.total_deaths / tt.total_cases * 100) AS FR, (tt.total_recovered / tt.total_cases * 100) AS PR, tt.last_updated AS lastUpdated
-  FROM worldometers tt
-  INNER JOIN
-  (
-    SELECT country,
-    max(last_updated) AS MaxDateTime
-    FROM worldometers tt
-    ${blacklistCountryQuery}
-    GROUP BY country
-  )
-  groupedtt ON tt.country = groupedtt.country
-  AND tt.last_updated = groupedtt.MaxDateTime
-  LEFT JOIN
-  (
-    SELECT country_name,
-    country_code,
-    country_alias,
-    latitude,
-    longitude
-    FROM apps_countries
-  )
-  AS ac ON tt.country = ac.country_alias
-  ${countryCodeQuery}
-  GROUP BY tt.country
-  ORDER BY tt.total_cases DESC
-  LIMIT ?`;
+  SELECT total_cases AS totalConfirmed, total_deaths as totalDeaths, total_recovered as totalRecovered, last_updated as lastUpdated
+  FROM worldometers_total_sum_temp
+  GROUP BY date(last_updated)
+  ORDER BY last_updated DESC;
+`;
 
-
-  let result = await conn.query(query, args);
-  const data = result[0]
-  const updatedData = updateCountryDetailStatsWithCustomStats(data, limit, getAllFlag)
-  return updatedData
-}
-
-// Get custom stats from GoogleSheetApi
-// Update countryStats values if it's greater
-async function updateCountryDetailStatsWithCustomStats(data, limit=999, getAllFlag) {
-  try {
-    const customStats = await getCustomStats();
-
-    const overriddenData = data.map(d => {
-      const customCountryStat = customStats.find(c => c.countryCode && d.countryCode && c.countryCode.toLowerCase() === d.countryCode.toLowerCase());
-
-      if (!customCountryStat) {
-        return d;
-      }
-
-      return {
-        ...d,
-        totalConfirmed: Math.max(d.totalConfirmed, customCountryStat.confirmed),
-        totalDeaths: Math.max(d.totalDeaths, customCountryStat.deaths),
-        totalRecovered: Math.max(d.totalRecovered, customCountryStat.recovered),
-      }
-    });
-
-    // Add custom country stats if it does not exist in current data.
-    // only use this when we're getting all data
-    if (getAllFlag) {
-      customStats.forEach(cs => {
-        if (!cs.countryCode || typeof cs.countryCode !== 'string') {
-          return false;
-        }
-
-        /* Format of expected data
-          {
-            "countryCode": "CN",
-            "country": "China",
-            "lat": 35.86166,
-            "lng": 104.195397,
-            "totalConfirmed": 81171,
-            "totalDeaths": 3277,
-            "totalRecovered": 73159,
-            "dailyConfirmed": 0,
-            "dailyDeaths": 0,
-            "activeCases": 4735,
-            "totalCritical": 1573,
-            "totalConfirmedPerMillionPopulation": 56,
-            "FR": "4.0372",
-            "PR": "90.1295",
-            "lastUpdated": "2020-03-25T08:50:30.000Z"
-          }
-        */
-        if (!overriddenData.find(d => d.countryCode.toLowerCase() === cs.countryCode.toLowerCase())) {
-          overriddenData.push({
-            countryCode: cs.countryCode,
-            country: cs.countryName,
-            lat: cs.lat || 0,
-            lng: cs.lng || 0,
-            totalConfirmed: cs.confirmed || 0,
-            totalDeaths: cs.deaths || 0,
-            totalRecovered: cs.recovered || 0,
-            dailyConfirmed: cs.dailyConfirmed || 0,
-            dailyDeaths: cs.dailyDeaths || 0,
-            activeCases: cs.activeCases || 0,
-            totalCritical: cs.totalCritical || 0,
-            totalConfirmedPerMillionPopulation: cs.totalConfirmedPerMillionPopulation || 0,
-            FR: cs.FR || "0",
-            PR: cs.PR || "0",
-            lastUpdated: new Date(),
-          });
-        }
-      });
-    }
-
-    return overriddenData
-      .sort((a, b) => {
-        // Sort by recovered desc if confirmed is same
-        if (b.totalConfirmed === a.totalConfirmed) {
-          return b.totalRecovered - a.totalRecovered;
-        }
-
-        // Sort by confirmed desc
-        return b.totalConfirmed - a.totalConfirmed;
-      })
-      // Take first {limit} results.
-      .slice(0, limit);
-  } catch (e) {
-    console.log("[getCustomStatsWithCountryDetail] error:", e);
-    return data;
-  }
+  let result = await conn.query(query);
+  return result[0];
 }
 
 module.exports = router;

--- a/services/statsService.js
+++ b/services/statsService.js
@@ -142,7 +142,7 @@ async function getCountryStats(countryCode=null, limit=999) {
   args.push(parseInt(limit))
 
   let query = `
-  SELECT ac.country_code AS countryCode, tt.country, tt.total_cases AS totalConfirmed, tt.total_deaths AS totalDeaths, tt.total_recovered AS totalRecovered, tt.new_cases AS dailyConfirmed, tt.new_deaths AS dailyDeaths, tt.active_cases AS activeCases, tt.serious_critical_cases AS totalCritical, CAST(tt.total_cases_per_million_pop AS UNSIGNED) AS totalConfirmedPerMillionPopulation, (tt.total_deaths / tt.total_cases * 100) AS FR, (tt.total_recovered / tt.total_cases * 100) AS PR, tt.last_updated AS lastUpdated
+  SELECT ac.country_code AS countryCode, tt.country, ac.latitude + 0.0 AS lat, ac.longitude + 0.0 AS lng, tt.total_cases AS totalConfirmed, tt.total_deaths AS totalDeaths, tt.total_recovered AS totalRecovered, tt.new_cases AS dailyConfirmed, tt.new_deaths AS dailyDeaths, tt.active_cases AS activeCases, tt.serious_critical_cases AS totalCritical, CAST(tt.total_cases_per_million_pop AS UNSIGNED) AS totalConfirmedPerMillionPopulation, (tt.total_deaths / tt.total_cases * 100) AS FR, (tt.total_recovered / tt.total_cases * 100) AS PR, tt.last_updated AS lastUpdated
   FROM worldometers tt
   INNER JOIN
   (
@@ -158,7 +158,9 @@ async function getCountryStats(countryCode=null, limit=999) {
   (
     SELECT country_name,
     country_code,
-    country_alias
+    country_alias,
+    latitude,
+    longitude
     FROM apps_countries
   )
   AS ac ON tt.country = ac.country_alias

--- a/services/statsService.js
+++ b/services/statsService.js
@@ -20,7 +20,7 @@ async function getStatsWithCountryDetail(limit = 999, date = null) {
 
   const conn = db.conn.promise();
   const args = [];
-  
+
   let dateQuery = '(SELECT MAX(posted_date) FROM arcgis)'
   if (date) {
     const dateFrom = moment(date).format('YYYY-MM-DD')
@@ -47,7 +47,7 @@ ON
   A.country = AC.country_alias
   AND A.posted_date = ${dateQuery}
 GROUP BY
-  A.country, A.posted_date 
+  A.country, A.posted_date
 ORDER BY
   confirmed DESC, recovered DESC`;
 
@@ -108,6 +108,138 @@ ORDER BY
   }
 }
 
+/**
+ * Returns array of object with following keys:
+ * - countryCode
+ * - country
+ * - totalConfirmed
+ * - totalDeaths
+ * - totalRecovered
+ * - dailyConfirmed
+ * - dailyDeaths
+ * - activeCases
+ * - totalCritical
+ * - totalConfirmedPerMillionPopulation
+ * - FR
+ * - PR
+ * - lastUpdated
+ * @param countryCode
+ * @param limit
+ * @returns {Promise<*>}
+ */
+async function getCountryStats(countryCode=null, limit=999) {
+
+  const conn = db.conn.promise();
+  let countryCodeQuery = ''
+  let args = []
+  let getAllFlag = true
+
+  if (countryCode) {
+    countryCodeQuery = 'WHERE ac.country_code=?'
+    args.push(countryCode)
+    getAllFlag = false
+  }
+  args.push(parseInt(limit))
+
+  let query = `
+  SELECT ac.country_code AS countryCode, tt.country, tt.total_cases AS totalConfirmed, tt.total_deaths AS totalDeaths, tt.total_recovered AS totalRecovered, tt.new_cases AS dailyConfirmed, tt.new_deaths AS dailyDeaths, tt.active_cases AS activeCases, tt.serious_critical_cases AS totalCritical, CAST(tt.total_cases_per_million_pop AS UNSIGNED) AS totalConfirmedPerMillionPopulation, (tt.total_deaths / tt.total_cases * 100) AS FR, (tt.total_recovered / tt.total_cases * 100) AS PR, tt.last_updated AS lastUpdated
+  FROM worldometers tt
+  INNER JOIN
+  (
+    SELECT country,
+    max(last_updated) AS MaxDateTime
+    FROM worldometers tt
+    WHERE country NOT in ("Sint Maarten","Congo", "South Korea", "Czechia Republic", "Czech Republic", "Others")
+    GROUP BY country
+  )
+  groupedtt ON tt.country = groupedtt.country
+  AND tt.last_updated = groupedtt.MaxDateTime
+  LEFT JOIN
+  (
+    SELECT country_name,
+    country_code,
+    country_alias
+    FROM apps_countries
+  )
+  AS ac ON tt.country = ac.country_alias
+  ${countryCodeQuery}
+  GROUP BY tt.country
+  ORDER BY tt.total_cases DESC
+  LIMIT ?`;
+
+
+  let result = await conn.query(query, args);
+  const data = result[0]
+  const updatedData = updateCountryDetailStatsWithCustomStats(data, limit, getAllFlag)
+  return updatedData
+}
+
+async function updateCountryDetailStatsWithCustomStats(data, limit=999, getAllFlag=true) {
+  try {
+    const customStats = await getCustomStats();
+
+    const overriddenData = data.map(d => {
+      const customCountryStat = customStats.find(c => c.countryCode && d.countryCode && c.countryCode.toLowerCase() === d.countryCode.toLowerCase());
+
+      if (!customCountryStat) {
+        return d;
+      }
+
+      return {
+        ...d,
+        totalConfirmed: Math.max(d.totalConfirmed, customCountryStat.confirmed),
+        totalDeaths: Math.max(d.totalDeaths, customCountryStat.deaths),
+        totalRecovered: Math.max(d.totalRecovered, customCountryStat.recovered),
+      }
+    });
+
+    // Add custom country stats if it does not exist in current data.
+    // only use this when we're getting all data
+    if (getAllFlag) {
+      customStats.forEach(cs => {
+        if (!cs.countryCode || typeof cs.countryCode !== 'string') {
+          return false;
+        }
+
+        if (!overriddenData.find(d => d.countryCode.toLowerCase() === cs.countryCode.toLowerCase())) {
+          overriddenData.push({
+            countryCode: cs.countryCode,
+            country: cs.countryName,
+            totalConfirmed: cs.confirmed || 0,
+            totalDeaths: cs.deaths || 0,
+            totalRecovered: cs.recovered || 0,
+            dailyConfirmed: cs.dailyConfirmed || 0,
+            dailyDeaths: cs.dailyDeaths || 0,
+            activeCases: cs.activeCases || 0,
+            totalCritical: cs.totalCritical || 0,
+            totalConfirmedPerMillionPopulation: cs.totalConfirmedPerMillionPopulation || 0,
+            FR: cs.FR || "0",
+            PR: cs.PR || "0",
+            lastUpdated: new Date(),
+          });
+        }
+      });
+    }
+
+    return overriddenData
+      .sort((a, b) => {
+        // Sort by recovered desc if confirmed is same
+        if (b.totalConfirmed === a.totalConfirmed) {
+          return b.totalRecovered - a.totalRecovered;
+        }
+
+        // Sort by confirmed desc
+        return b.totalConfirmed - a.totalConfirmed;
+      })
+      // Take first {limit} results.
+      .slice(0, limit);
+  } catch (e) {
+    console.log("[updateCountryDetailStatsWithCustomStats] error:", e);
+    return data;
+  }
+}
+
 module.exports = {
   getStatsWithCountryDetail,
+  getCountryStats,
 };

--- a/services/statsService.js
+++ b/services/statsService.js
@@ -207,6 +207,8 @@ async function updateCountryDetailStatsWithCustomStats(data, limit=999, getAllFl
           overriddenData.push({
             countryCode: cs.countryCode,
             country: cs.countryName,
+            lat: cs.lat || 0,
+            lng: cs.lng || 0,
             totalConfirmed: cs.confirmed || 0,
             totalDeaths: cs.deaths || 0,
             totalRecovered: cs.recovered || 0,

--- a/test/api_test.js
+++ b/test/api_test.js
@@ -219,7 +219,7 @@ describe ("Get worldometer stats", function(){
     })
 })
 
-describe ("Get stats overview", function(){
+describe ("Get worldometer global stats overview", function(){
     it ("Should get ", (done)=>{
         chai.request(server)
             .get("/v3/stats/worldometer/global")
@@ -238,10 +238,87 @@ describe ("Get stats overview", function(){
     })
 })
 
-describe ("Get total trending cases", function(){
+describe ("Get worldometer all country stats", function(){
     it ("Should get ", (done)=>{
         chai.request(server)
-            .get("/v3/stats/total_trending_cases")
+            .get("/v3/stats/worldometer/country")
+            .end((err, result)=>{
+                var country_count = result.body.length;
+                console.log('got '+ country_count + ' countries');
+                if (country_count > 0){
+                    result.should.have.status(200)
+                    console.log('Test pass');
+                }
+                else{
+                    assert.fail("There are 0 countries");
+                }
+                done();
+            })
+    })
+})
+
+describe ("Get worldometer 1 country stats", function(){
+    let countryCode = "MY"
+    it ("Should get ", (done)=>{
+        chai.request(server)
+            .get("/v3/stats/worldometer/country?countryCode=" + countryCode)
+            .end((err, result)=>{
+                var country_count = result.body.length;
+                console.log('got '+ country_count + ' countries');
+                if (country_count == 1){
+                    result.should.have.status(200)
+                    console.log('Test pass');
+                }
+                else{
+                    assert.fail("There are " + country_count + " countries. Expecting 1.");
+                }
+                done();
+            })
+    })
+})
+
+describe ("Get worldometer top country stats", function(){
+    it ("Should get ", (done)=>{
+        chai.request(server)
+            .get("/v3/stats/worldometer/topCountry")
+            .end((err, result)=>{
+                var country_count = result.body.length;
+                console.log('got '+ country_count + ' countries');
+                if (country_count > 0){
+                    result.should.have.status(200)
+                    console.log('Test pass');
+                }
+                else{
+                    assert.fail("There are " + country_count + " countries. Expecting more than 0.");
+                }
+                done();
+            })
+    })
+})
+
+describe ("Get worldometer top 3 country stats", function(){
+    it ("Should get ", (done)=>{
+        chai.request(server)
+            .get("/v3/stats/worldometer/topCountry?limit=3")
+            .end((err, result)=>{
+                var country_count = result.body.length;
+                console.log('got '+ country_count + ' countries');
+                if (country_count == 3){
+                    result.should.have.status(200)
+                    console.log('Test pass');
+                }
+                else{
+                    assert.fail("There are " + country_count + " countries. Expecting 3.");
+                }
+                done();
+            })
+    })
+})
+
+describe ("Get worldometer total trending cases", function(){
+    it ("Should get ", (done)=>{
+        chai.request(server)
+            .get("/v3/stats/worldometer/totalTrendingCases")
             .end((err, result)=>{
                 var num_results = result.body.length;
                 console.log('got '+ num_results + ' results');
@@ -251,6 +328,102 @@ describe ("Get total trending cases", function(){
                 }
                 else{
                     assert.fail("There are 0 results");
+                }
+                done();
+            })
+    })
+})
+
+describe ("Get worldonmeter dailyNewStats (analytics)", function(){
+    it ("Should get ", (done)=>{
+        chai.request(server)
+            .get("/v3/analytics/dailyNewStats")
+            .end((err, result)=>{
+                var num_results = result.body.length;
+                console.log('got '+ num_results + ' results');
+                if (num_results > 0){
+                    result.should.have.status(200)
+                    console.log('Test pass');
+                }
+                else{
+                    assert.fail("There are 0 results");
+                }
+                done();
+            })
+    })
+})
+
+describe ("Get worldonmeter dailyNewStats with limits (analytics)", function(){
+    it ("Should get ", (done)=>{
+        chai.request(server)
+            .get("/v3/analytics/dailyNewStats?limit=2")
+            .end((err, result)=>{
+                var num_results = result.body.length;
+                console.log('got '+ num_results + ' results');
+                if (num_results == 2){
+                    result.should.have.status(200)
+                    console.log('Test pass');
+                }
+                else{
+                    assert.fail("There are " + num_results + " results. Expecting 2.");
+                }
+                done();
+            })
+    })
+})
+
+describe ("Get worldonmeter trend data of country (analytics). No parameter", function(){
+    it ("Should get ", (done)=>{
+        let expected_response = "Invalid date format"
+        chai.request(server)
+            .get("/v3/analytics/trend/country")
+            .end((err, result)=>{
+                var response = result.body;
+                console.log('got '+ response + ' response');
+                if (response.includes(expected_response)){
+                    console.log('Test pass');
+                }
+                else{
+                    assert.fail("Fail to fail.");
+                }
+                done();
+            })
+    })
+})
+
+describe ("Get worldonmeter trend data of a single country (analytics)", function(){
+    it ("Should get ", (done)=>{
+        chai.request(server)
+            .get("/v3/analytics/trend/country?countryCode=MY&startDate=2020-03-20&endDate=2020-03-24")
+            .end((err, result)=>{
+                var num_results = result.body.length;
+                console.log('got '+ num_results + ' data');
+                if (num_results > 0){
+                    result.should.have.status(200)
+                    console.log('Test pass');
+                }
+                else{
+                    assert.fail("There are " + num_results + " results. Expecting 2.");
+                }
+                done();
+            })
+    })
+})
+
+
+describe ("Get worldonmeter trend data of multiple countries (analytics)", function(){
+    it ("Should get ", (done)=>{
+        chai.request(server)
+            .get("/v3/analytics/trend/country?countryCode=MY,CN&startDate=2020-03-20&endDate=2020-03-24")
+            .end((err, result)=>{
+                var num_results = result.body.length;
+                console.log('got '+ num_results + ' data');
+                if (num_results > 0){
+                    result.should.have.status(200)
+                    console.log('Test pass');
+                }
+                else{
+                    assert.fail("There are " + num_results + " results. Expecting 2.");
                 }
                 done();
             })


### PR DESCRIPTION
- `/v3/analytics/daily` -> `/v3/analytics/dailyNewStats`
- `/v3/stats/total_trending_cases` -> `/v3/stats/worldometer/totalTrendingCases` (since it's relying on worldometer)
- `/v3/stats/worldometer/top` -> `/v3/stats/worldometer/topCountry`
- removed `/v3/analytics/country`, use `/v3/stats/worldometer/country` since they're identical
- move `getCountryStats()` (for  `/v3/stats/worldometer/country`) to `statsService`, it compares with googlesheet `customStats` as well
- updated tests

Any feedback is appreciated, goal of this is to add clarity to endpoints, and code readability (as much as possible)