### PR TITLE
Apply singleton design pattern to database connector

### DIFF
--- a/system/database.js
+++ b/system/database.js
@@ -2,61 +2,72 @@ require('dotenv').config()
 const fs = require('fs');
 const mysql = require('mysql2');
 
-const readConfig = {
-    host: process.env.DB_HOST_READ,
-    user: process.env.DB_USER_READ,
-    password: process.env.DB_PASSWORD_READ,
-    database: process.env.DB_TABLE_READ,
+class DatabaseConnector {
+    conn; // Read pool
+    connWrite; // Write pool
 
-    // https://github.com/sidorares/node-mysql2/issues/642#issuecomment-347500996
-    timezone: '+00:00', // Interpret all received timestamps as UTC. Otherwise local timezone is assumed.
-};
-
-if (process.env.DB_READ_SSL_CERT_PATH) {
-    readConfig.ssl = {
-        ca: fs.readFileSync(__dirname + process.env.DB_READ_SSL_CERT_PATH),
-    };
-}
-
-const readPool = mysql.createPool(readConfig);
-
-readPool.on('connection', conn => {
-    conn.query("SET time_zone='+00:00';", error => {
-        if (error) {
-            console.log('Error connecting to read database:', error);
-            throw error;
+    constructor() {
+        // Ensure there only ever exists a single instance of DatabaseConnector
+        if (DatabaseConnector._instance) {
+            return DatabaseConnector._instance;
         }
-    });
-});
 
-const writeConfig = {
-    host: process.env.DB_HOST_WRITE,
-    user: process.env.DB_USER_WRITE,
-    password: process.env.DB_PASSWORD_WRITE,
-    database: process.env.DB_TABLE_WRITE,
+        const baseConfig = {
+            // https://github.com/sidorares/node-mysql2/issues/642#issuecomment-347500996
+            timezone: '+00:00', // Interpret all received timestamps as UTC. Otherwise local timezone is assumed.
+        };
+        const readConfig = {
+            ...baseConfig,
+            host: process.env.DB_HOST_READ,
+            user: process.env.DB_USER_READ,
+            password: process.env.DB_PASSWORD_READ,
+            database: process.env.DB_TABLE_READ,
+        };
+        const writeConfig = {
+            ...baseConfig,
+            host: process.env.DB_HOST_WRITE,
+            user: process.env.DB_USER_WRITE,
+            password: process.env.DB_PASSWORD_WRITE,
+            database: process.env.DB_TABLE_WRITE,
+        };
 
-    // https://github.com/sidorares/node-mysql2/issues/642#issuecomment-347500996
-    timezone: '+00:00', // Interpret all received timestamps as UTC. Otherwise local timezone is assumed.
-};
-
-if (process.env.DB_WRITE_SSL_CERT_PATH) {
-    readConfig.ssl = {
-        ca: fs.readFileSync(__dirname + process.env.DB_WRITE_SSL_CERT_PATH),
-    };
-}
-
-const writePool = mysql.createPool(writeConfig);
-
-writePool.on('connection', conn => {
-    conn.query("SET time_zone='+00:00';", error => {
-        if (error) {
-            console.log('Error connecting to write database:', error);
-            throw error;
+        if (process.env.DB_READ_SSL_CERT_PATH) {
+            readConfig.ssl = {
+                ca: fs.readFileSync(__dirname + process.env.DB_READ_SSL_CERT_PATH),
+            };
         }
-    });
-});
+        if (process.env.DB_WRITE_SSL_CERT_PATH) {
+            writeConfig.ssl = {
+                ca: fs.readFileSync(__dirname + process.env.DB_WRITE_SSL_CERT_PATH),
+            };
+        }
 
-module.exports = {
-    conn: readPool,
-    connWrite: writePool,
+        this.readPool = mysql.createPool(readConfig);
+        this.writePool = mysql.createPool(writeConfig);
+
+        this.readPool.on('connection', conn => this._setTimeZone(conn, 'read'));
+        this.writePool.on('connection', conn => this._setTimeZone(conn, 'write'));
+
+        DatabaseConnector._instance = this;
+        return DatabaseConnector._instance;
+    }
+
+    get conn() {
+        return this.readPool;
+    }
+
+    get connWrite() {
+        return this.writePool;
+    }
+
+    _setTimeZone(conn, poolName) => {
+        conn.query("SET time_zone='+00:00';", error => {
+            if (error) {
+                console.log(`Error connecting to ${pool_name} database:`, error);
+                throw error;
+            }
+        });
+    }
 }
+
+module.exports = new DatabaseConnector();


### PR DESCRIPTION
This PR refactors the database connector to use the singleton pattern. This was done as follows:
1. The code was modified and aggregated into an ES6 class. This creates clearer boundaries around the code.
2. `DatabaseConnector._instance` is a static variable created to store the one and only instance of `DatabaseConnector`
3. At the start of the constructor, the code checks if this one instance exists. If it does, it immediately returns, otherwise construction happens as normal.
4. The initialization of the read and write pool happens in a similar fashion as before, with the only difference being some data was shared, such as `baseConfig` and the `_setTimeZone()` method.

Notes:
- `conn` and `connWrite` were intentionally kept the same name as the previous implementation to avoid breaking references to this code.
- The methods `conn()` and `connWrite()` were bound with the ES6 `get` syntax. This offers a cleaner interface (by not requiring brackets when calling them), while also maintaining the previous interface.
- Following JavaScript conventions, private members of the class are prefixed with `_`